### PR TITLE
feat: promote to GA again

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ If you are using Maven, add this to your pom.xml file:
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-implementation 'com.google.cloud:google-cloud-domains:0.6.1'
+implementation 'com.google.cloud:google-cloud-domains:0.7.0'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-domains" % "0.6.1"
+libraryDependencies += "com.google.cloud" % "google-cloud-domains" % "0.7.0"
 ```
 
 ## Authentication


### PR DESCRIPTION
Somehow the previous pull request didn't bump the major version:
https://github.com/googleapis/java-domains/pull/171

Release-As: 1.0.0
